### PR TITLE
Add ThrottlingException to uploadDocument api

### DIFF
--- a/apis/cloudsearchdomain-2013-01-01.normal.json
+++ b/apis/cloudsearchdomain-2013-01-01.normal.json
@@ -46,7 +46,8 @@
       "input":{"shape":"UploadDocumentsRequest"},
       "output":{"shape":"UploadDocumentsResponse"},
       "errors":[
-        {"shape":"DocumentServiceException"}
+        {"shape":"DocumentServiceException"},
+        {"shape":"ThrottlingException"}
       ],
       "documentation":"<p>Posts a batch of documents to a search domain for indexing. A document batch is a collection of add and delete operations that represent the documents you want to add, update, or delete from your domain. Batches can be described in either JSON or XML. Each item that you want Amazon CloudSearch to return as a search result (such as a product) is represented as a document. Every document has a unique ID and one or more fields that contain the data that you want to search and return in results. Individual documents cannot contain more than 1 MB of data. The entire batch cannot exceed 5 MB. To get the best possible upload performance, group add and delete operations in batches that are close the 5 MB limit. Submitting a large volume of single-document batches can overload a domain's document service. </p> <p>The endpoint for submitting <code>UploadDocuments</code> requests is domain-specific. To get the document endpoint for your domain, use the Amazon CloudSearch configuration service <code>DescribeDomains</code> action. A domain's endpoints are also displayed on the domain dashboard in the Amazon CloudSearch console. </p> <p>For more information about formatting your data for Amazon CloudSearch, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/preparing-data.html\">Preparing Your Data</a> in the <i>Amazon CloudSearch Developer Guide</i>. For more information about uploading data for indexing, see <a href=\"http://docs.aws.amazon.com/cloudsearch/latest/developerguide/uploading-data.html\">Uploading Data</a> in the <i>Amazon CloudSearch Developer Guide</i>. </p>"
     }
@@ -499,6 +500,15 @@
       "member":{"shape":"SuggestionMatch"}
     },
     "SuggestionsSize":{"type":"long"},
+    "ThrottlingException":{
+      "type":"structure",
+      "members":{
+        "message":{"shape":"ErrorMessage"}
+      },
+      "documentation":"<p>The limit on the number of requests per second was exceeded.</p>",
+      "error":{"httpStatusCode":400},
+      "exception":true
+    },
     "UploadDocumentsRequest":{
       "type":"structure",
       "required":[


### PR DESCRIPTION
It is possible for the uploadDocument api to be throttled. Currently the error results in an unhandled exception being thrown.

This fixes #1605